### PR TITLE
Add fixed socials icons

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
 import { StoreInitializer } from "@/components/store-initializer"
+import Socials from "@/components/socials"
 import "./globals.css"
 import { hvFlorentino, roboto } from "./fonts"
 import "swiper/css"
@@ -26,6 +27,7 @@ export default function RootLayout({
       <body className={`${hvFlorentino.variable} ${roboto.variable}`}>
         <StoreInitializer />
         {children}
+        <Socials />
       </body>
     </html>
   )

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -1,0 +1,25 @@
+import { Facebook, Instagram } from "lucide-react"
+import type { SVGProps } from "react"
+
+const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" fill="currentColor" stroke="none" />
+    <path d="M8 8h8l-8 8h8" />
+  </svg>
+)
+
+export default function Socials() {
+  return (
+    <div className="fixed bottom-20 right-4 z-50 flex flex-col items-center space-y-2">
+      <a href="#" target="_blank" rel="noopener noreferrer" aria-label="Facebook" className="rounded-full bg-primary p-3 text-white hover:bg-primary/90">
+        <Facebook className="h-5 w-5" />
+      </a>
+      <a href="#" target="_blank" rel="noopener noreferrer" aria-label="Zalo" className="rounded-full bg-primary p-3 text-white hover:bg-primary/90">
+        <ZaloIcon className="h-5 w-5" />
+      </a>
+      <a href="#" target="_blank" rel="noopener noreferrer" aria-label="Instagram" className="rounded-full bg-primary p-3 text-white hover:bg-primary/90">
+        <Instagram className="h-5 w-5" />
+      </a>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new Socials component with Facebook, Zalo, Instagram icons
- include Socials component globally via `app/layout.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f78180c08833182b17797b3c88011