### PR TITLE
Update Zalo icon

### DIFF
--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -2,9 +2,17 @@ import { Facebook, Instagram } from "lucide-react"
 import type { SVGProps } from "react"
 
 const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
-    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" fill="currentColor" stroke="none" />
-    <path d="M8 8h8l-8 8h8" />
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" />
+    <path d="M9 8h6l-6 6h6" />
   </svg>
 )
 

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -2,7 +2,16 @@ import { Facebook, Instagram } from "lucide-react"
 import type { SVGProps } from "react"
 
 const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
- <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="svg" version="1.1" width="400" height="400" viewBox="0, 0, 400,400"><g id="svgg"><path id="path0" d="" stroke="none" fill="#040404" fill-rule="evenodd"/><path id="path1" d="" stroke="none" fill="#080404" fill-rule="evenodd"/><path id="path2" d="" stroke="none" fill="#080404" fill-rule="evenodd"/><path id="path3" d="" stroke="none" fill="#080404" fill-rule="evenodd"/><path id="path4" d="" stroke="none" fill="#080404" fill-rule="evenodd"/></g></svg>
+    <text
+      x="12"
+      y="13"
+      fontSize="6"
+      textAnchor="middle"
+      fontWeight="bold"
+      dominantBaseline="middle"
+    >
+      Zalo
+    </text>
 )
 
 export default function Socials() {

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -2,18 +2,7 @@ import { Facebook, Instagram } from "lucide-react"
 import type { SVGProps } from "react"
 
 const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    {...props}
-  >
-    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" />
-    <path d="M8 8h8l-8 8h8" />
-  </svg>
+ <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="svg" version="1.1" width="400" height="400" viewBox="0, 0, 400,400"><g id="svgg"><path id="path0" d="" stroke="none" fill="#040404" fill-rule="evenodd"/><path id="path1" d="" stroke="none" fill="#080404" fill-rule="evenodd"/><path id="path2" d="" stroke="none" fill="#080404" fill-rule="evenodd"/><path id="path3" d="" stroke="none" fill="#080404" fill-rule="evenodd"/><path id="path4" d="" stroke="none" fill="#080404" fill-rule="evenodd"/></g></svg>
 )
 
 export default function Socials() {

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -2,20 +2,24 @@ import { Facebook, Instagram } from "lucide-react"
 import type { SVGProps } from "react"
 
 const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
-    xmlns="http://www.w3.org/2000/svg"
-    xmlnsXlink="http://www.w3.org/1999/xlink"
-    id="svg"
-    version="1.1"
-    width="400"
-    height="400"
-    viewBox="0 0 400 400"
-    <g id="svgg">
-      <path id="path0" d="" stroke="none" fill="#040404" fillRule="evenodd" />
-      <path id="path1" d="" stroke="none" fill="#080404" fillRule="evenodd" />
-      <path id="path2" d="" stroke="none" fill="#080404" fillRule="evenodd" />
-      <path id="path3" d="" stroke="none" fill="#080404" fillRule="evenodd" />
-      <path id="path4" d="" stroke="none" fill="#080404" fillRule="evenodd" />
-    </g>
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    <circle cx={12} cy={12} r={10} />
+    <text
+      x={12}
+      y={16}
+      textAnchor="middle"
+      fontFamily="sans-serif"
+      fontSize={6}
+      fill="currentColor"
+      stroke="none"
+    >
+      Zalo
+    </text>
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Facebook"

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -11,12 +11,12 @@ function ZaloIcon(props: SVGProps<SVGSVGElement>) {
       strokeLinecap="round"
       strokeLinejoin="round"
       {...props}
-      <circle cx={12} cy={12} r={10} />
+      <circle cx={12} cy={12} r={11} />
       <text
-        x={12}
-        y={12}
-        textAnchor="middle"
+        x="50%"
+        y="50%"
         dominantBaseline="middle"
+        textAnchor="middle"
         fontFamily="sans-serif"
         fontSize={6}
         fill="currentColor"
@@ -27,7 +27,7 @@ function ZaloIcon(props: SVGProps<SVGSVGElement>) {
     </svg>
   )
 }
-      >
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1 text-white hover:bg-primary/90"
         <Facebook className="h-full w-full" />
       </a>
       <a
@@ -35,7 +35,7 @@ function ZaloIcon(props: SVGProps<SVGSVGElement>) {
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Zalo"
-        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1.5 text-white hover:bg-primary/90"
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1 text-white hover:bg-primary/90"
       >
         <ZaloIcon className="h-full w-full" />
       </a>
@@ -44,7 +44,7 @@ function ZaloIcon(props: SVGProps<SVGSVGElement>) {
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Instagram"
-        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1.5 text-white hover:bg-primary/90"
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1 text-white hover:bg-primary/90"
       >
         <Instagram className="h-full w-full" />
       </a>

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -1,30 +1,32 @@
 import { Facebook, Instagram } from "lucide-react"
 import type { SVGProps } from "react"
 
-const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" />
-    <text
-      x={12}
-      y={12}
-      textAnchor="middle"
-      dominantBaseline="middle"
-      fontFamily="sans-serif"
-      fontSize={6}
-      fill="currentColor"
-      stroke="none"
-    >
-      Zalo
-    </text>
-);
-        rel="noopener noreferrer"
-        aria-label="Facebook"
-        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1.5 text-white hover:bg-primary/90"
+function ZaloIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+      <circle cx={12} cy={12} r={10} />
+      <text
+        x={12}
+        y={12}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontFamily="sans-serif"
+        fontSize={6}
+        fill="currentColor"
+        stroke="none"
+      >
+        Zalo
+      </text>
+    </svg>
+  )
+}
       >
         <Facebook className="h-full w-full" />
       </a>

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -20,7 +20,7 @@ const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
     >
       Zalo
     </text>
-        target="_blank"
+);
         rel="noopener noreferrer"
         aria-label="Facebook"
         className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1.5 text-white hover:bg-primary/90"

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -8,11 +8,12 @@ const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
     strokeWidth={2}
     strokeLinecap="round"
     strokeLinejoin="round"
-    <circle cx={12} cy={12} r={10} />
+    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" />
     <text
       x={12}
-      y={16}
+      y={12}
       textAnchor="middle"
+      dominantBaseline="middle"
       fontFamily="sans-serif"
       fontSize={6}
       fill="currentColor"

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -2,23 +2,20 @@ import { Facebook, Instagram } from "lucide-react"
 import type { SVGProps } from "react"
 
 const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
-    <text
-      x="12"
-      y="13"
-      fontSize="6"
-      textAnchor="middle"
-      fontWeight="bold"
-      dominantBaseline="middle"
-    >
-      Zalo
-    </text>
-)
-
-export default function Socials() {
-  return (
-    <div className="fixed bottom-20 right-4 z-50 flex flex-col items-center space-y-2">
-      <a
-        href="#"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    id="svg"
+    version="1.1"
+    width="400"
+    height="400"
+    viewBox="0 0 400 400"
+    <g id="svgg">
+      <path id="path0" d="" stroke="none" fill="#040404" fillRule="evenodd" />
+      <path id="path1" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+      <path id="path2" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+      <path id="path3" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+      <path id="path4" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+    </g>
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Facebook"

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -11,8 +11,18 @@ const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
     strokeLinejoin="round"
     {...props}
   >
-    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" />
-    <path d="M9 8h6l-6 6h6" />
+    <circle cx="12" cy="12" r="10" />
+    <text
+      x="12"
+      y="16"
+      textAnchor="middle"
+      fontSize="6"
+      fontFamily="inherit"
+      fill="currentColor"
+      stroke="none"
+    >
+      Zalo
+    </text>
   </svg>
 )
 

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -4,26 +4,19 @@ import type { SVGProps } from "react"
 function ZaloIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 400 400"
+      width="100%"
+      height="100%"
       {...props}
-      <circle cx={12} cy={12} r={11} />
-      <text
-        x="50%"
-        y="50%"
-        dominantBaseline="middle"
-        textAnchor="middle"
-        fontFamily="sans-serif"
-        fontSize={6}
-        fill="currentColor"
-        stroke="none"
-      >
-        Zalo
-      </text>
+      <g>
+        <path id="path0" d="" stroke="none" fill="#040404" fillRule="evenodd" />
+        <path id="path1" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+        <path id="path2" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+        <path id="path3" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+        <path id="path4" d="" stroke="none" fill="#080404" fillRule="evenodd" />
+      </g>
     </svg>
   )
 }

--- a/components/socials.tsx
+++ b/components/socials.tsx
@@ -11,32 +11,40 @@ const ZaloIcon = (props: SVGProps<SVGSVGElement>) => (
     strokeLinejoin="round"
     {...props}
   >
-    <circle cx="12" cy="12" r="10" />
-    <text
-      x="12"
-      y="16"
-      textAnchor="middle"
-      fontSize="6"
-      fontFamily="inherit"
-      fill="currentColor"
-      stroke="none"
-    >
-      Zalo
-    </text>
+    <path d="M4 3h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H7l-5 5V4a1 1 0 0 1 1-1z" />
+    <path d="M8 8h8l-8 8h8" />
   </svg>
 )
 
 export default function Socials() {
   return (
     <div className="fixed bottom-20 right-4 z-50 flex flex-col items-center space-y-2">
-      <a href="#" target="_blank" rel="noopener noreferrer" aria-label="Facebook" className="rounded-full bg-primary p-3 text-white hover:bg-primary/90">
-        <Facebook className="h-5 w-5" />
+      <a
+        href="#"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Facebook"
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1.5 text-white hover:bg-primary/90"
+      >
+        <Facebook className="h-full w-full" />
       </a>
-      <a href="#" target="_blank" rel="noopener noreferrer" aria-label="Zalo" className="rounded-full bg-primary p-3 text-white hover:bg-primary/90">
-        <ZaloIcon className="h-5 w-5" />
+      <a
+        href="#"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Zalo"
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1.5 text-white hover:bg-primary/90"
+      >
+        <ZaloIcon className="h-full w-full" />
       </a>
-      <a href="#" target="_blank" rel="noopener noreferrer" aria-label="Instagram" className="rounded-full bg-primary p-3 text-white hover:bg-primary/90">
-        <Instagram className="h-5 w-5" />
+      <a
+        href="#"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Instagram"
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-primary p-1.5 text-white hover:bg-primary/90"
+      >
+        <Instagram className="h-full w-full" />
       </a>
     </div>
   )


### PR DESCRIPTION
## Summary
- tweak the Zalo icon so it uses line style matching other social icons

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850eb8428b08331805f98b45229a5de